### PR TITLE
Vagrant/init

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,77 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "base"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,10 +5,84 @@ lb1 = {
   box: 'centos/7',
   cpus: '1',
   memory: '512',
-  #provisioner_path: './lb_config.sh'
+  #provisioner_path: ''
 }
 
-virtual_machines = [lb1]
+lb2 = {
+  hostname: 'LB2',
+  box: 'centos/7',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+wb1 = {
+  hostname: 'WB1',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+wb2 = {
+  hostname: 'WB2',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+wb3 = {
+  hostname: 'WB3',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+db1 = {
+  hostname: 'DB1',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+db2 = {
+  hostname: 'DB2',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+db3 = {
+  hostname: 'DB3',
+  box: 'ubuntu/xenial64',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+log = {
+  hostname: 'LOG',
+  box: 'centos/7',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: ''
+}
+
+virtual_machines = [
+  lb1,
+  lb2,
+  wb1,
+  wb2,
+  wb3,
+  db1,
+  db2,
+  db3,
+  log
+]
 
 Vagrant.configure("2") do |config|
   virtual_machines.each do |machine|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 class VirtualMachine
   attr_accessor :hostname, :box, :cpus, :memory
   def initialize(options ={})
-    self.hostname = options[:hostname] || 'unnamed'
+    self.hostname = options[:hostname]
     self.box = options[:box] || 'ubuntu/xenial64'
     self.cpus = options[:cpus] || '1'
     self.memory = options[:memory] || '512'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,77 +1,27 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
+# vi: set ft=ruby:
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
+lb1 = {
+  hostname: 'LB1',
+  box: 'centos/7',
+  cpus: '1',
+  memory: '512',
+  #provisioner_path: './lb_config.sh'
+}
+
+virtual_machines = [lb1]
+
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "base"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # NOTE: This will enable public access to the opened port
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine and only allow access
-  # via 127.0.0.1 to disable public access
-  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
+  virtual_machines.each do |machine|
+    config.vm.define machine[:hostname] do |machine_config|
+      machine_config.vm.box = machine[:box]
+      machine_config.vm.hostname = machine[:hostname]
+      machine_config.vm.network :public_network
+      machine_config.vm.provider :virtualbox do |vbox|
+        vbox.name = machine[:hostname]
+        vbox.memory = machine[:memory]
+        vbox.cpus = machine[:cpus]
+      end
+      #machine_config.vm.provision "shell", path: machine[:provisioner_path]
+    end
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,99 +1,37 @@
 # vi: set ft=ruby:
 
-lb1 = {
-  hostname: 'LB1',
-  box: 'centos/7',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-lb2 = {
-  hostname: 'LB2',
-  box: 'centos/7',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-wb1 = {
-  hostname: 'WB1',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-wb2 = {
-  hostname: 'WB2',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-wb3 = {
-  hostname: 'WB3',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-db1 = {
-  hostname: 'DB1',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-db2 = {
-  hostname: 'DB2',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-db3 = {
-  hostname: 'DB3',
-  box: 'ubuntu/xenial64',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
-
-log = {
-  hostname: 'LOG',
-  box: 'centos/7',
-  cpus: '1',
-  memory: '512',
-  #provisioner_path: ''
-}
+class VirtualMachine
+  attr_accessor :hostname, :box, :cpus, :memory
+  def initialize(options ={})
+    self.hostname = options[:hostname] || 'unnamed'
+    self.box = options[:box] || 'ubuntu/xenial64'
+    self.cpus = options[:cpus] || '1'
+    self.memory = options[:memory] || '512'
+  end
+end
 
 virtual_machines = [
-  lb1,
-  lb2,
-  wb1,
-  wb2,
-  wb3,
-  db1,
-  db2,
-  db3,
-  log
+  VirtualMachine.new(hostname: 'LB1', box: 'centos/7'),
+  VirtualMachine.new(hostname: 'LB2', box: 'centos/7'),
+  VirtualMachine.new(hostname: 'WB1'),
+  VirtualMachine.new(hostname: 'WB2'),
+  VirtualMachine.new(hostname: 'WB3'),
+  VirtualMachine.new(hostname: 'DB1'),
+  VirtualMachine.new(hostname: 'DB2'),
+  VirtualMachine.new(hostname: 'DB3'),
+  VirtualMachine.new(hostname: 'LOG', box: 'centos/7'),
 ]
 
 Vagrant.configure("2") do |config|
   virtual_machines.each do |machine|
-    config.vm.define machine[:hostname] do |machine_config|
-      machine_config.vm.box = machine[:box]
-      machine_config.vm.hostname = machine[:hostname]
+    config.vm.define machine.hostname do |machine_config|
+      machine_config.vm.box = machine.box
+      machine_config.vm.hostname = machine.hostname
       machine_config.vm.network :public_network
       machine_config.vm.provider :virtualbox do |vbox|
-        vbox.name = machine[:hostname]
-        vbox.memory = machine[:memory]
-        vbox.cpus = machine[:cpus]
+        vbox.name = machine.hostname
+        vbox.memory = machine.memory
+        vbox.cpus = machine.cpus
       end
       #machine_config.vm.provision "shell", path: machine[:provisioner_path]
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,9 @@ Vagrant.configure("2") do |config|
       node_config.vm.box = node.box
       node_config.vm.hostname = node.hostname
       node_config.vm.network :public_network
+
+      node_config.vm.synced_folder ".", "/vagrant", disabled: true
+
       node_config.vm.provider :virtualbox do |vbox|
         vbox.name = node.hostname
         vbox.memory = node.memory

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # vi: set ft=ruby:
 
-class VirtualMachine
+class VM
   attr_accessor :hostname, :box, :cpus, :memory
   def initialize(options ={})
     self.hostname = options[:hostname]
@@ -10,30 +10,30 @@ class VirtualMachine
   end
 end
 
-virtual_machines = [
-  VirtualMachine.new(hostname: 'LB1', box: 'centos/7'),
-  VirtualMachine.new(hostname: 'LB2', box: 'centos/7'),
-  VirtualMachine.new(hostname: 'WB1'),
-  VirtualMachine.new(hostname: 'WB2'),
-  VirtualMachine.new(hostname: 'WB3'),
-  VirtualMachine.new(hostname: 'DB1'),
-  VirtualMachine.new(hostname: 'DB2'),
-  VirtualMachine.new(hostname: 'DB3'),
-  VirtualMachine.new(hostname: 'LOG', box: 'centos/7'),
+nodes  = [
+  VM.new(hostname: 'lb1', box: 'centos/7'),
+  VM.new(hostname: 'lb2', box: 'centos/7'),
+  VM.new(hostname: 'wb1'),
+  VM.new(hostname: 'wb2'),
+  VM.new(hostname: 'wb3'),
+  VM.new(hostname: 'db1'),
+  VM.new(hostname: 'db2'),
+  VM.new(hostname: 'db3'),
+  VM.new(hostname: 'log', box: 'centos/7'),
 ]
 
 Vagrant.configure("2") do |config|
-  virtual_machines.each do |machine|
-    config.vm.define machine.hostname do |machine_config|
-      machine_config.vm.box = machine.box
-      machine_config.vm.hostname = machine.hostname
-      machine_config.vm.network :public_network
-      machine_config.vm.provider :virtualbox do |vbox|
-        vbox.name = machine.hostname
-        vbox.memory = machine.memory
-        vbox.cpus = machine.cpus
+  nodes.each do |node|
+    config.vm.define node.hostname do |node_config|
+      node_config.vm.box = node.box
+      node_config.vm.hostname = node.hostname
+      node_config.vm.network :public_network
+      node_config.vm.provider :virtualbox do |vbox|
+        vbox.name = node.hostname
+        vbox.memory = node.memory
+        vbox.cpus = node.cpus
       end
-      #machine_config.vm.provision "shell", path: machine[:provisioner_path]
+      #node_config.vm.provision "shell", path: node[:provisioner_path]
     end
   end
 end


### PR DESCRIPTION
Initial setup for Vagrantfile, this uses a virtualmachine class to define a vm. The class has defaults built in, but also offers options to make changes for specific vms. I think having a class define the vm offers more flexibility and readability. 

Networking is currently set up as public for each vm but will likely need to be changed once we determine which machines are public vs private 

Provisioning with shell scripts is commented out for now 

Will likely need to add handling for vagrant plugins in the future, ie hostmanager 

May change class name VirtualMachine to just VM