### PR TITLE
Terraform configuration for all nodes

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,14 +1,14 @@
-# Web ervers
+# Web servers
 
 resource "aws_instance" "web" {
     count = 3
-    ami = ""
-    instance_type = ""
-    subnet_id = ""
-    vpc_security_group_ids = [""]
-    key_name = ""
+    ami = "${var.ubuntu-ami}"
+    instance_type = "${var.web-instance-type}"
+    subnet_id = "pass"
+    vpc_security_group_ids = ["pass"]
+    key_name = "pass"
 
-    user_date = ""
+    user_data = "pass"
 
     tags = {
         Name = "wb${count.index}"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "web" {
     instance_type = "${var.web-instance-type}"
     subnet_id = "${aws_subnet.public.id}"
     vpc_security_group_ids = ["pass"]
-    key_name = "pass"
+    key_name = "${aws_key_pair.eclipse.key_name}"
 
     user_data = "pass"
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -1,0 +1,17 @@
+# Web ervers
+
+resource "aws_instance" "web" {
+    count = 3
+    ami = ""
+    instance_type = ""
+    subnet_id = ""
+    vpc_security_group_ids = [""]
+    key_name = ""
+
+    user_date = ""
+
+    tags = {
+        Name = "wb${count.index}"
+        group = "eclipse-ec2"
+    }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -33,3 +33,38 @@ resource "aws_instance" "db" {
         group = "eclipse-ec2"
     }
 }
+
+# Load balancers
+
+resource "aws_instance" "lb" {
+    count = 2
+    ami = "${var.rhel-ami}"
+    instance_type = "${var.lb-instance-type}"
+    subnet_id = "${aws_subnet.public.id}"
+    vpc_security_group_ids = ["pass"]
+    key_name = "${aws_key_pair.eclipse.key_name}"
+
+    user_data = "${data.template_file.user_data.rendered}"
+
+    tags = {
+        Name = "lb${count.index}"
+        group = "eclipse-ec2"
+    }
+}
+
+# Logging server
+
+resource "aws_instance" "log" {
+    ami = "${var.rhel-ami}"
+    instance_type = "${var.log-instance-type}"
+    subnet_id = "${aws_subnet.public.id}"
+    vpc_security_group_ids = ["pass"]
+    key_name = "${aws_key_pair.eclipse.key_name}"
+
+    user_data = "${data.template_file.user_data.rendered}"
+
+    tags = {
+        Name = "log"
+        group = "eclipse-ec2"
+    }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "web" {
     ami = "${var.ubuntu-ami}"
     instance_type = "${var.web-instance-type}"
     subnet_id = "${aws_subnet.public.id}"
-    vpc_security_group_ids = ["pass"]
+    vpc_security_group_ids = ["${aws_security_group.eclipse.id}", "${aws_security_group.internal.id}"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
     user_data = "${data.template_file.user_data.rendered}"
@@ -23,7 +23,7 @@ resource "aws_instance" "db" {
     ami = "${var.ubuntu-ami}"
     instance_type = "${var.db-instance-type}"
     subnet_id = "${aws_subnet.public.id}"
-    vpc_security_group_ids = ["pass"]
+    vpc_security_group_ids = ["${aws_security_group.eclipse.id}", "${aws_security_group.internal.id}"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
     user_data = "${data.template_file.user_data.rendered}"
@@ -41,7 +41,7 @@ resource "aws_instance" "lb" {
     ami = "${var.rhel-ami}"
     instance_type = "${var.lb-instance-type}"
     subnet_id = "${aws_subnet.public.id}"
-    vpc_security_group_ids = ["pass"]
+    vpc_security_group_ids = ["${aws_security_group.eclipse.id}", "${aws_security_group.internal.id}"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
     user_data = "${data.template_file.user_data.rendered}"
@@ -58,7 +58,7 @@ resource "aws_instance" "log" {
     ami = "${var.rhel-ami}"
     instance_type = "${var.log-instance-type}"
     subnet_id = "${aws_subnet.public.id}"
-    vpc_security_group_ids = ["pass"]
+    vpc_security_group_ids = ["${aws_security_group.eclipse.id}", "${aws_security_group.internal.id}"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
     user_data = "${data.template_file.user_data.rendered}"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -15,3 +15,21 @@ resource "aws_instance" "web" {
         group = "eclipse-ec2"
     }
 }
+
+# Database servers
+
+resource "aws_instance" "db" {
+    count = 3
+    ami = "${var.ubuntu-ami}"
+    instance_type = "${var.db-instance-type}"
+    subnet_id = "${aws_subnet.public.id}"
+    vpc_security_group_ids = ["pass"]
+    key_name = "${aws_key_pair.eclipse.key_name}"
+
+    user_data = "pass"
+
+    tags = {
+        Name = "db${count.index}"
+        group = "eclipse-ec2"
+    }
+}

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "web" {
     vpc_security_group_ids = ["pass"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
-    user_data = "pass"
+    user_data = "${data.template_file.user_data.rendered}"
 
     tags = {
         Name = "wb${count.index}"
@@ -26,7 +26,7 @@ resource "aws_instance" "db" {
     vpc_security_group_ids = ["pass"]
     key_name = "${aws_key_pair.eclipse.key_name}"
 
-    user_data = "pass"
+    user_data = "${data.template_file.user_data.rendered}"
 
     tags = {
         Name = "db${count.index}"

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "web" {
     count = 3
     ami = "${var.ubuntu-ami}"
     instance_type = "${var.web-instance-type}"
-    subnet_id = "pass"
+    subnet_id = "${aws_subnet.public.id}"
     vpc_security_group_ids = ["pass"]
     key_name = "pass"
 

--- a/terraform/key-pair.tf
+++ b/terraform/key-pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "eclipse" {
+    key_name = "eclipse-key"
+    public_key = "${file("ssh/eclipse-key.pub")}"
+}

--- a/terraform/security-groups.tf
+++ b/terraform/security-groups.tf
@@ -1,0 +1,57 @@
+# NAT instance security group
+resource "aws_security_group" "eclipse" {
+    name = "eclipse"
+    description = "Security group for "
+    vpc_id = "${aws_vpc.default.id}"
+
+    ingress {
+        from_port = 22
+        to_port = 22
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    ingress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port = 0
+        to_port = 0
+        protocol = -1
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    tags {
+        Name = "eclipse"
+        group = "eclipse-sg"
+    }
+}
+
+resource "aws_security_group" "internal" {
+	name = "internal"
+    description = "All ports open for cross group traffic"
+    vpc_id = "${aws_vpc.default.id}"
+
+	ingress {
+		from_port = 0
+		to_port = 0
+		protocol = -1
+		security_groups = ["${aws_security_group.eclipse.id}"]
+    }
+
+    tags {
+        Name = "internal"
+        group = "eclipse-sg"
+    }
+}

--- a/terraform/subnet-public.tf
+++ b/terraform/subnet-public.tf
@@ -1,0 +1,32 @@
+# Gateway for public subnet
+resource "aws_internet_gateway" "default" {
+    vpc_id = "${aws_vpc.eclipse.id}"
+}
+
+# Public subnet
+resource "aws_subnet" "public" {
+    vpc_id = "${aws_vpc.eclipse.id}"
+    cidr_block = "10.66.0.0/24"
+    availability_zone = "us-west-2a"
+    map_public_ip_on_launch = true
+    depends_on = ["aws_internet_gateway.default"]
+    tags {
+        Name = "public"
+        group = "eclipse-subnet"
+    }
+}
+
+# Routing table
+resource "aws_route_table" "public" {
+    vpc_id = "${aws_vpc.eclipse.id}"
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = "${aws_internet_gateway.default.id}"
+    }
+}
+
+# Associate routing table
+resource "aws_route_table_association" "public" {
+    subnet_id = "${aws_subnet.public.id}"
+    route_table_id = "${aws_route_table.public.id}"
+}

--- a/terraform/templates.tf
+++ b/terraform/templates.tf
@@ -1,0 +1,5 @@
+data "template_file" "user_data" {
+    template = "${file("templates/user_data.tpl")}"
+
+    vars {}
+}

--- a/terraform/templates/user_data.tpl
+++ b/terraform/templates/user_data.tpl
@@ -1,0 +1,1 @@
+echo "Config complete"

--- a/terraform/var-ec2.tf
+++ b/terraform/var-ec2.tf
@@ -17,3 +17,13 @@ variable "db-instance-type" {
     description = "EC2 instance type for database servers"
     default = "t2.micro"
 }
+
+variable "lb-instance-type" {
+    description = "EC2 instance type for load balancers" 
+    default = "t2.micro"
+}
+
+variable "log-instance-type" {
+    description = "EC2 instance type for logging server" 
+    default = "t2.micro"
+}

--- a/terraform/var-ec2.tf
+++ b/terraform/var-ec2.tf
@@ -1,0 +1,14 @@
+variable "rhel-ami" {
+    description = "RHEL AMI"
+    default = "ami-b55a51cc" # Red Hat Enterprise Linux 7.3 (HVM)
+}
+
+variable "ubuntu-ami" {
+    description = "Ubuntu AMI"
+    default = "ami-835b4efa" # Ubuntu 16.04 (HVM)
+}
+
+variable "web-instance-type" {
+    description = "EC2 instance type for web servers"
+    default = "t2.micro"
+}

--- a/terraform/var-ec2.tf
+++ b/terraform/var-ec2.tf
@@ -12,3 +12,8 @@ variable "web-instance-type" {
     description = "EC2 instance type for web servers"
     default = "t2.micro"
 }
+
+variable "db-instance-type" {
+    description = "EC2 instance type for database servers"
+    default = "t2.micro"
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+    region = "us-west-2"
+}
+
+resource "aws_vpc" "eclipse" {
+    cidr_block = "10.66.0.0/16"
+    enable_dns_hostnames = true
+    tags {
+        Name = "eclipse"
+        group = "eclipse-vpc"
+    }
+}


### PR DESCRIPTION
Allows repeatable, programmatic creation of required AWS infrastructure for testing Eclipse configuration.

Very basic configuration, creates all nine nodes, t2.micro, sets up VPC, security groups, SSH key, etc.