### PR TITLE
Cloud config to bootstrap live nodes

### DIFF
--- a/docs/utilities/cloud-config.md
+++ b/docs/utilities/cloud-config.md
@@ -1,0 +1,7 @@
+# Cloud Config
+
+The file `./util/deploy-init.yml` is a [Cloud Config](http://cloudinit.readthedocs.io/en/latest/index.html)
+configuration which can be used to bootstrap new nodes that can be added to the
+cluster. New nodes will have a user `deploy` created, who belongs to the `sudo`
+group. In addition, this user is allowed full passwordless `sudo` privileges.
+SSH keys are added via the GitHub convenience `https://github.com/<user>.keys`.

--- a/docs/utilities/cloud-config.md
+++ b/docs/utilities/cloud-config.md
@@ -5,3 +5,21 @@ configuration which can be used to bootstrap new nodes that can be added to the
 cluster. New nodes will have a user `deploy` created, who belongs to the `sudo`
 group. In addition, this user is allowed full passwordless `sudo` privileges.
 SSH keys are added via the GitHub convenience `https://github.com/<user>.keys`.
+
+### Local Simulation With LXC
+
+[LXC](https://linuxcontainers.org/) can be used along with `./util/deploy-init.yml`
+to simulate a node locally. The following commands will create a profile that
+mimics the setup used for bootstrapping live nodes.
+
+```
+# Create and configure a new profile
+lxc profile create eclipse
+lxc profile set eclipse user.user-data - < util/deploy-init.yml
+
+# Launch a new container 'TEST1'
+lxc launch [<remote>:]<image> TEST1 -p default -p eclipse
+
+# Login to container
+lxc exec TEST1 bash
+```

--- a/util/deploy-init.yml
+++ b/util/deploy-init.yml
@@ -1,0 +1,21 @@
+#cloud-config
+users:
+  - name: deploy
+    gecos: Deploy User
+    groups: sudo
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    shell: /bin/bash
+    lock-passwd: false
+    passwd: 0AJWvkaQQLytY
+
+runcmd:
+  - mkdir -p /home/deploy/.ssh/
+  - touch /home/deploy/.ssh/authorized_keys
+  - curl https://github.com/jerrywardlow.keys >> /home/deploy/.ssh/authorized_keys
+  - curl https://github.com/Rickymare.keys >> /home/deploy/.ssh/authorized_keys
+  - curl https://github.com/yevgenybulochnik.keys >> /home/deploy/.ssh/authorized_keys
+  - chown -R deploy: /home/deploy/
+  - chmod 0700 /home/deploy/.ssh/
+  - chmod 0600 /home/deploy/.ssh/authorized_keys
+
+final_message: "Total time: $UPTIME"


### PR DESCRIPTION
This PR includes a cloud config file which will bootstrap new nodes with the `deploy` user. It includes current user SSH keys and passwordless sudo privileges. This file can be used to automate the creation of new, blank nodes to a consistent and repeatable state.